### PR TITLE
Prevent build DI container on initialize extension

### DIFF
--- a/src/Kdyby/Redis/DI/RedisExtension.php
+++ b/src/Kdyby/Redis/DI/RedisExtension.php
@@ -117,7 +117,7 @@ class RedisExtension extends \Nette\DI\CompilerExtension
 		$builder = $this->getContainerBuilder();
 
 		// overwrite
-		$journalService = $builder->getByType(\Nette\Caching\Storages\IJournal::class) ?: 'nette.cacheJournal';
+		$journalService = /*$builder->getByType(\Nette\Caching\Storages\IJournal::class) ?:*/ 'nette.cacheJournal';
 		$builder->removeDefinition($journalService);
 		$builder->addDefinition($journalService)->setFactory($this->prefix('@cacheJournal'));
 
@@ -140,7 +140,7 @@ class RedisExtension extends \Nette\DI\CompilerExtension
 			'locks' => TRUE,
 		]);
 
-		$storageService = $builder->getByType(\Nette\Caching\Storage::class) ?: 'cacheStorage';
+		$storageService = /*$builder->getByType(\Nette\Caching\Storage::class) ?:*/ 'cacheStorage';
 		$builder->removeDefinition($storageService);
 		$builder->addDefinition($storageService)->setFactory($this->prefix('@cacheStorage'));
 


### PR DESCRIPTION
Fixed bug when there are configured service dependencies for default nette extensions - example Nette Database conventions

Example config which leads to exception Nette\DI\ServiceCreationException: Service 'database.default.reflection': Reference to missing service 'defaultDatabaseReflection'.

```
services:
	defaultDatabaseReflection:
		factory: Andweb\Database\Conventions\Conventions('id', '%s_id', '%s', @database.default.structure)

database:
	default:
		dsn: 'mysql:host=mysql;dbname=database'
		user: user
		password: xxx
		reflection: @defaultDatabaseReflection
```